### PR TITLE
🔧 Update `pyproject.toml`

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,6 @@ passlib = {extras = ["bcrypt"], version = "^1.7.4"}
 tenacity = "^8.2.3"
 pydantic = ">2.0"
 emails = "^0.6"
-
 gunicorn = "^22.0.0"
 jinja2 = "^3.1.4"
 alembic = "^1.12.1"


### PR DESCRIPTION
Removed empty line which caused poetry to omit import of additional modules without throwing an error.
(You can test this by keeping the empty line and changing the version of a module after the empty line - notice the module will not update in the updated docker image.)