### PR TITLE
Update copier.yml to use python3

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -99,4 +99,4 @@ _exclude:
 _answers_file: .copier/.copier-answers.yml
 
 _tasks:
-  - "python .copier/update_dotenv.py"
+  - "python3 .copier/update_dotenv.py"


### PR DESCRIPTION
When trying to run the copier command you receive and error due to python not being a recognised command line command.  Switched the config to use python3 instead.