### PR TITLE
♻️ Remove duplicate information in the ItemCreate model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -64,7 +64,7 @@ class ItemBase(SQLModel):
 
 # Properties to receive on item creation
 class ItemCreate(ItemBase):
-    title: str = Field(min_length=1, max_length=255)
+    pass
 
 
 # Properties to receive on item update


### PR DESCRIPTION
ItemBase already contains the title field, so to me it seems defining the title field again in ItemCreate is redundant.