### PR TITLE
💚 Set `include-hidden-files` to `True` when using the `upload-artifact` GH action

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,6 +52,7 @@ jobs:
         name: playwright-report
         path: frontend/playwright-report/
         retention-days: 30
+        include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   e2e-alls-green:  # This job does nothing and is only used for the branch protection

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           name: coverage-html
           path: backend/htmlcov
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   alls-green:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
Since `actions/upload-artifact` [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0), hidden files are excluded by default. This PR specifically sets the `include-hidden-files` parameter to `True` to ensure all behaviour remains the same as before.
