### PR TITLE
👷 Improve playwright CI job

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,9 +41,9 @@ jobs:
       working-directory: frontend
     - run: docker compose build
     - run: docker compose down -v --remove-orphans
-    - run: docker compose up -d
+    - run: docker compose up -d --wait
     - name: Run Playwright tests
-      run: npx playwright test
+      run: npx playwright test --fail-on-flaky-tests --trace=retain-on-failure
       working-directory: frontend
     - run: docker compose down -v --remove-orphans
     - uses: actions/upload-artifact@v4

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -24,3 +24,8 @@ def test_email(email_to: EmailStr) -> Message:
         html_content=email_data.html_content,
     )
     return Message(message="Test email sent")
+
+
+@router.get("/health-check/")
+async def health_check() -> bool:
+    return True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,12 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
       - SENTRY_DSN=${SENTRY_DSN}
 
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/api/v1/utils/health-check/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
     build:
       context: ./backend
       args:

--- a/frontend/src/client/services.ts
+++ b/frontend/src/client/services.ts
@@ -386,6 +386,18 @@ export class UtilsService {
       },
     })
   }
+
+  /**
+   * Health Check
+   * @returns boolean Successful Response
+   * @throws ApiError
+   */
+  public static healthCheck(): CancelablePromise<boolean> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/utils/health-check/",
+    })
+  }
 }
 
 export type TDataReadItems = {


### PR DESCRIPTION
This PR adds:

1. health check for the backend[1]
2. `--fail-on-flaky-tests` as a good practise to write less flaky tests, I assume in future you might want to disable this if your CI gets complex, but I think it should be turned on by default
3. `--trace=retain-on-failure` for easier debug when something fails (you can download the failing trace from the artifacts)


[1] Ideally you'd do some additional checks to see if we are able to connect to the backend, but for CI this is enough (we can also add health checks for the db if needed) 😊