### PR TITLE
🐛 Fix log print for utils

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -12,6 +12,10 @@ from jwt.exceptions import InvalidTokenError
 from app.core.config import settings
 
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class EmailData:
     html_content: str


### PR DESCRIPTION
In the code, there is only this line: 
https://github.com/fastapi/full-stack-fastapi-template/blob/451c656fb052c9ff00e0da507a42d549c0f184cb/backend/app/utils.py#L1
```
response = message.send(to=email_to, smtp=smtp_options)
logging.info(f"send email result: {response}")
```

Without any log configuration (such as setting the log level, format, and handler), in most cases, this log message will not be displayed on the console, nor will it be automatically recorded in a log file.
https://github.com/fastapi/full-stack-fastapi-template/blob/451c656fb052c9ff00e0da507a42d549c0f184cb/backend/app/utils.py#L50C1-L51C51

I can't see the log `<emails.backend.SMTPResponse status_code=501 status_text=b'Mail from address must be same as authorization user.'>`
