### PR TITLE
🔧 Add .auth playwright folder to `.gitignore`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -27,3 +27,4 @@ openapi.json
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/playwright/.auth/


### PR DESCRIPTION
Currently when running playwright it creates a `.auth` folder which will contain a `user.json` file. This contains the `access_token` of the user used during testing. 

![image](https://github.com/user-attachments/assets/c7a62012-9697-4f04-8876-f2b1b32156b2)

It's less then ideal and not needed to commit this to source, as such the path has been added to the `.gitignore` file.