### PR TITLE
Prevent actions from running when unrelated changes are made

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -5,6 +5,19 @@ on:
     types:
     - opened
     - synchronize
+    paths-ignore:
+      - 'release-notes.md'
+      - development.md
+      - deployment.md
+      - SECURITY.md
+      - README.md
+      - LICENSE
+      - .pre-commit-config.yaml
+      - .gitignore
+      - .gitattributes
+      - img/*
+      - hooks/*
+      - .copier/*
 
 jobs:
   generate-client:
@@ -12,14 +25,10 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-    # For PRs from forks
     - uses: actions/checkout@v4
-    # For PRs from the same repo
-    - uses: actions/checkout@v4
-      if: ( github.event_name != 'pull_request' || github.secret_source == 'Actions' )
       with:
         ref: ${{ github.head_ref }}
-        token: ${{ secrets.FULL_STACK_FASTAPI_TEMPLATE_REPO_TOKEN }}
+        token: ${{ github.token }}
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
@@ -39,19 +48,10 @@ jobs:
     - run: uv run bash scripts/generate-client.sh
       env:
         VIRTUAL_ENV: backend/.venv
-    - name: Add changes to git
+    - name: Commit changes
       run: |
         git config --local user.email "github-actions@github.com"
         git config --local user.name "github-actions"
         git add frontend/src/client
-    # Same repo PRs
-    - name: Push changes
-      if: ( github.event_name != 'pull_request' || github.secret_source == 'Actions' )
-      run: |
         git diff --staged --quiet || git commit -m "✨ Autogenerate frontend client"
         git push
-    # Fork PRs
-    - name: Check changes
-      if: ( github.event_name == 'pull_request' && github.secret_source != 'Actions' )
-      run: |
-        git diff --staged --quiet || (echo "Changes detected in generated client, run scripts/generate-client.sh and commit the changes" && exit 1)

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -3,11 +3,40 @@ name: Lint Backend
 on:
   push:
     branches:
-      - master
+      - main
+    paths-ignore:
+      - 'release-notes.md'
+      - renovate.json
+      - development.md
+      - deployment.md
+      - SECURITY.md
+      - README.md
+      - LICENSE
+      - .pre-commit-config.yaml
+      - .gitignore
+      - .gitattributes
+      - .editorconfig
+      - '.better-commits.json'
+      - img/*
+      - hooks/*
+      - .copier/*
   pull_request:
     types:
       - opened
       - synchronize
+    paths-ignore:
+      - 'release-notes.md'
+      - development.md
+      - deployment.md
+      - SECURITY.md
+      - README.md
+      - LICENSE
+      - .pre-commit-config.yaml
+      - .gitignore
+      - .gitattributes
+      - img/*
+      - hooks/*
+      - .copier/*
 
 jobs:
   lint-backend:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,11 +3,37 @@ name: Playwright Tests
 on:
   push:
     branches:
-    - master
+    - main
+    paths-ignore:
+      - 'release-notes.md'
+      - development.md
+      - deployment.md
+      - SECURITY.md
+      - README.md
+      - LICENSE
+      - .pre-commit-config.yaml
+      - .gitignore
+      - .gitattributes
+      - img/*
+      - hooks/*
+      - .copier/*
   pull_request:
     types:
     - opened
     - synchronize
+    paths-ignore:
+      - 'release-notes.md'
+      - development.md
+      - deployment.md
+      - SECURITY.md
+      - README.md
+      - LICENSE
+      - .pre-commit-config.yaml
+      - .gitignore
+      - .gitattributes
+      - img/*
+      - hooks/*
+      - .copier/*
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -3,11 +3,37 @@ name: Test Backend
 on:
   push:
     branches:
-      - master
+      - main
+    paths-ignore:
+      - 'release-notes.md'
+      - development.md
+      - deployment.md
+      - SECURITY.md
+      - README.md
+      - LICENSE
+      - .pre-commit-config.yaml
+      - .gitignore
+      - .gitattributes
+      - img/*
+      - hooks/*
+      - .copier/*
   pull_request:
     types:
       - opened
       - synchronize
+    paths-ignore:
+      - 'release-notes.md'
+      - development.md
+      - deployment.md
+      - SECURITY.md
+      - README.md
+      - LICENSE
+      - .pre-commit-config.yaml
+      - .gitignore
+      - .gitattributes
+      - img/*
+      - hooks/*
+      - .copier/*
 
 jobs:
   test-backend:


### PR DESCRIPTION
This change effectively prevents a playwright or a backend test from running when you for example update a README.md file. 

Currently when updating certain files that do not effect the outcome of tests in anyway will trigger Actions to run regardless. To prevent unneeded credits being used or charges being made when this template is used on private repositories certain files have been added as a `paths-ignore` on relevant actions. 