### PR TITLE
Add MJML extension to recommended vscode workspace extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vscode
+.vscode/*
+!.vscode/extensions.json
 node_modules/
 /test-results/
 /playwright-report/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "attilabuti.vscode-mjml"
+    ]
+}


### PR DESCRIPTION
This change will prompt developers to install the MJML extension when they open the project in vscode.