### PR TITLE
📝 Add MailCatcher to `development.md`

### DIFF
--- a/development.md
+++ b/development.md
@@ -186,6 +186,8 @@ Adminer: http://localhost:8080
 
 Traefik UI: http://localhost:8090
 
+MailCatcher: http://localhost:1080
+
 ### Development URLs with `localhost.tiangolo.com` Configured
 
 Development URLs, for local development.
@@ -201,3 +203,5 @@ Automatic Alternative Docs (ReDoc): http://api.localhost.tiangolo.comredoc
 Adminer: http://localhost.tiangolo.com:8080
 
 Traefik UI: http://localhost.tiangolo.com:8090
+
+MailCatcher: http://localhost.tiangolo.com:1080

--- a/development.md
+++ b/development.md
@@ -196,9 +196,9 @@ Frontend: http://dashboard.localhost.tiangolo.com
 
 Backend: http://api.localhost.tiangolo.com
 
-Automatic Interactive Docs (Swagger UI): http://api.localhost.tiangolo.comdocs
+Automatic Interactive Docs (Swagger UI): http://api.localhost.tiangolo.com/docs
 
-Automatic Alternative Docs (ReDoc): http://api.localhost.tiangolo.comredoc
+Automatic Alternative Docs (ReDoc): http://api.localhost.tiangolo.com/redoc
 
 Adminer: http://localhost.tiangolo.com:8080
 


### PR DESCRIPTION
Add MailCatcher URLs to docs and fix typo in URLs for API docs accessed through `localhost.tiangolo.com`.