### PR TITLE
Putting `extensions.json` under `.vscode`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-python.python"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}


### PR DESCRIPTION
Hey folks. With this file, we can specify what extensions of VSCode should be used together with this template, and people can easily be prompted in VSCode to install them. I only added Python extension from Microsoft as it's needed to run the debugger. Please let me know what you think, thanks!