### PR TITLE
Update password max length

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,19 +14,19 @@ class UserBase(SQLModel):
 
 # Properties to receive via API on creation
 class UserCreate(UserBase):
-    password: str = Field(min_length=8, max_length=40)
+    password: str = Field(min_length=8, max_length=45)
 
 
 class UserRegister(SQLModel):
     email: EmailStr = Field(max_length=255)
-    password: str = Field(min_length=8, max_length=40)
+    password: str = Field(min_length=8, max_length=45)
     full_name: str | None = Field(default=None, max_length=255)
 
 
 # Properties to receive via API on update, all are optional
 class UserUpdate(UserBase):
     email: EmailStr | None = Field(default=None, max_length=255)  # type: ignore
-    password: str | None = Field(default=None, min_length=8, max_length=40)
+    password: str | None = Field(default=None, min_length=8, max_length=45)
 
 
 class UserUpdateMe(SQLModel):
@@ -35,8 +35,8 @@ class UserUpdateMe(SQLModel):
 
 
 class UpdatePassword(SQLModel):
-    current_password: str = Field(min_length=8, max_length=40)
-    new_password: str = Field(min_length=8, max_length=40)
+    current_password: str = Field(min_length=8, max_length=45)
+    new_password: str = Field(min_length=8, max_length=45)
 
 
 # Database model, database table inferred from class name
@@ -111,4 +111,4 @@ class TokenPayload(SQLModel):
 
 class NewPassword(SQLModel):
     token: str
-    new_password: str = Field(min_length=8, max_length=40)
+    new_password: str = Field(min_length=8, max_length=45)


### PR DESCRIPTION
On my machine, the command provided to generate a password (using
python3 specifically), results in a 44 character string, while the
maximum allowable character length in the model is 40, causing a
conflict. This PR updates the max_legnth for all password model
definitions.

```
MacBook-Pro-3:full-stack-fastapi-template michaelalvarino$ python3 -c "import secrets; print(secrets.token_urlsafe(32))" | wc -c
      44
MacBook-Pro-3:full-stack-fastapi-template michaelalvarino$ python3 -c "import secrets; print(secrets.token_urlsafe(32))" | wc -c
      44
MacBook-Pro-3:full-stack-fastapi-template michaelalvarino$ python3 -c "import secrets; print(secrets.token_urlsafe(32))" | wc -c
      44
```
