### PR TITLE
🐛 Change get_user_by_email to be case insensetive

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from sqlmodel import Session, select
+from sqlmodel import Session, func, select
 
 from app.core.security import get_password_hash, verify_password
 from app.models import Item, ItemCreate, User, UserCreate, UserUpdate
@@ -32,7 +32,7 @@ def update_user(*, session: Session, db_user: User, user_in: UserUpdate) -> Any:
 
 
 def get_user_by_email(*, session: Session, email: str) -> User | None:
-    statement = select(User).where(User.email == email)
+    statement = select(User).where(func.lower(User.email) == func.lower(email))
     session_user = session.exec(statement).first()
     return session_user
 

--- a/backend/app/tests/crud/test_user.py
+++ b/backend/app/tests/crud/test_user.py
@@ -89,3 +89,27 @@ def test_update_user(db: Session) -> None:
     assert user_2
     assert user.email == user_2.email
     assert verify_password(new_password, user_2.hashed_password)
+
+
+def test_get_user_by_email(db: Session) -> None:
+    password = random_lower_string()
+    email = random_email()
+    user_in = UserCreate(email=email, password=password, is_superuser=True)
+    crud.create_user(session=db, user_create=user_in)
+    user = crud.get_user_by_email(session=db, email=email)
+    assert user
+    user_2 = db.get(User, user.id)
+    assert user_2
+    assert user.email == user_2.email
+
+
+def test_get_user_by_email_case_insesetive(db: Session) -> None:
+    password = random_lower_string()
+    email = random_email().lower()
+    user_in = UserCreate(email=email, password=password, is_superuser=True)
+    crud.create_user(session=db, user_create=user_in)
+    user = crud.get_user_by_email(session=db, email=email.upper())
+    assert user
+    user_2 = db.get(User, user.id)
+    assert user_2
+    assert user.email == user_2.email


### PR DESCRIPTION
Fix an issue where `get_user_by_email`  won't return a user object if the requested email case doesn't match the string in the database.