### PR TITLE
Bug | Refactor: Remove redundant item deletion code leveraging cascade delete

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -134,8 +134,6 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
         raise HTTPException(
             status_code=403, detail="Super users are not allowed to delete themselves"
         )
-    statement = delete(Item).where(col(Item.owner_id) == current_user.id)
-    session.exec(statement)  # type: ignore
     session.delete(current_user)
     session.commit()
     return Message(message="User deleted successfully")


### PR DESCRIPTION
Remove manual item deletion - cascade delete handles this
session.exec(delete(Item).where(Item.owner_id == current_user.id))