### PR TITLE
📝 Removing deprecated manual client SDK step

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -91,12 +91,6 @@ But it would be only to clean them up, leaving them won't really have any effect
 
 * Download the OpenAPI JSON file from `http://localhost/api/v1/openapi.json` and copy it to a new file `openapi.json` at the root of the `frontend` directory.
 
-* To simplify the names in the generated frontend client code, modify the `openapi.json` file by running the following script:
-
-```bash
-node modify-openapi-operationids.js
-```
-
 * To generate the frontend client, run:
 
 ```bash


### PR DESCRIPTION
Since openapi-ts was upgraded and  improved(https://github.com/fastapi/full-stack-fastapi-template/pull/1434, https://github.com/fastapi/full-stack-fastapi-template/pull/1430), we no longer need this step to simplify the names since the library will do this for us.