### PR TITLE
send account creation email asynchronously via BackgroundTasks

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -51,10 +51,13 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 @router.post(
     "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
 )
-def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
+def create_user(
+    *, session: SessionDep, user_in: UserCreate, background_tasks: BackgroundTasks
+) -> Any:
     """
     Create new user.
     """
+    
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
         raise HTTPException(
@@ -67,11 +70,12 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
         email_data = generate_new_account_email(
             email_to=user_in.email, username=user_in.email, password=user_in.password
         )
-        send_email(
+        background_tasks.add_task(
+            send_email,
             email_to=user_in.email,
             subject=email_data.subject,
             html_content=email_data.html_content,
-        )
+         )
     return user
 
 


### PR DESCRIPTION
Making it a background task improves responsiveness and user experience.
For future
If you need to perform heavy background computation and you don't necessarily need it to be run by the same process (for example, you don't need to share memory, variables, etc), you might benefit from using other bigger tools like [Celery](https://docs.celeryq.dev/)
According to the FastAPI docs :
https://fastapi.tiangolo.com/tutorial/background-tasks/?h=#technical-details