### PR TITLE
🐛 Fix required password validation when editing user fields

### DIFF
--- a/frontend/src/components/Admin/EditUser.tsx
+++ b/frontend/src/components/Admin/EditUser.tsx
@@ -129,7 +129,6 @@ const EditUser = ({ user }: EditUserProps) => {
               </Field>
 
               <Field
-                required
                 invalid={!!errors.password}
                 errorText={errors.password?.message}
                 label="Set Password"
@@ -148,7 +147,6 @@ const EditUser = ({ user }: EditUserProps) => {
               </Field>
 
               <Field
-                required
                 invalid={!!errors.confirm_password}
                 errorText={errors.confirm_password?.message}
                 label="Confirm Password"


### PR DESCRIPTION
Issue when editting the user fields, It was required that you mandatory put the password and the new password. If for example you just want to edit the user "is_active" you are enforced to put a new password.
In my use case I set the "is_active" to false when someone signs up, and I want to enable one per one the users without changhing their password. 
I think that it is a bug because the empty password is already handled here:

```
  const onSubmit: SubmitHandler<UserUpdateForm> = async (data) => {
    if (data.password === "") {
      data.password = undefined
    }
    mutation.mutate(data)
  }
```