### PR TITLE
🐛 Close sidebar drawer on user selection

### DIFF
--- a/frontend/src/components/Common/Sidebar.tsx
+++ b/frontend/src/components/Common/Sidebar.tsx
@@ -49,7 +49,7 @@ const Sidebar = () => {
           <DrawerBody>
             <Flex flexDir="column" justify="space-between">
               <Box>
-                <SidebarItems />
+                <SidebarItems onClose={() => setOpen(false)} />
                 <Flex
                   as="button"
                   onClick={() => {


### PR DESCRIPTION
Issue (on mobile/small screens): The SidebarItems component has an onClose prop that's being passed to the RouterLink onClick handler, but in the Sidebar component, we are not passing this prop to SidebarItems. 

Fix: Now when a user clicks on any navigation item in the sidebar or the logout button, the drawer will automatically close as the new page loads. The onClose function is passed to each RouterLink in the SidebarItems component, which will trigger when a user clicks on a menu option.