### PR TITLE
configure uv to use the latest version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app/
 
 # Install uv
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Place executables in the environment at the front of the path
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#using-the-environment


### PR DESCRIPTION
### Update backend Dockerfile to use the latest uv version.

### Reasons
1. I encountered an issue when building Docker images with the specific uv version (0.5.11). And switching to latest helped resolve the issue. 

1. Using latest ensures that we don’t have to manually update the version in the future. This approach aligns with the recommendations in the uv documentation.