### PR TITLE
🐛 Fix reset behavior in `EditItem` mutation on success

### DIFF
--- a/frontend/src/components/Items/EditItem.tsx
+++ b/frontend/src/components/Items/EditItem.tsx
@@ -56,9 +56,9 @@ const EditItem = ({ item }: EditItemProps) => {
   const mutation = useMutation({
     mutationFn: (data: ItemUpdateForm) =>
       ItemsService.updateItem({ id: item.id, requestBody: data }),
-    onSuccess: () => {
+    onSuccess: (_data: ItemPublic, variables: ItemUpdateForm) => {
       showSuccessToast("Item updated successfully.")
-      reset()
+      reset(variables)
       setIsOpen(false)
     },
     onError: (err: ApiError) => {


### PR DESCRIPTION
This PR fixes a bug where the ItemUpdateForm (in EditItem) would reset to its default values upon successful mutation. As a result, reopening the update form would display outdated predefined values. The fix ensures the form state is correctly updated with the latest item data after a successful update.