### PR TITLE
Update reset password message

### DIFF
--- a/frontend/src/routes/reset-password.tsx
+++ b/frontend/src/routes/reset-password.tsx
@@ -54,7 +54,7 @@ function ResetPassword() {
   const mutation = useMutation({
     mutationFn: resetPassword,
     onSuccess: () => {
-      showSuccessToast("Password updated successfully.")
+      showSuccessToast("Password updated successfully")
       reset()
       navigate({ to: "/login" })
     },


### PR DESCRIPTION
Remove the ending period in the password reset success message to pass playwright tests.