### PR TITLE
🐛 Fix `parse_cors` function to be consistent for both empty string and empty list

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,6 +18,8 @@ from typing_extensions import Self
 
 def parse_cors(v: Any) -> list[str] | str:
     if isinstance(v, str) and not v.startswith("["):
+        if not v.strip():
+            return []
         return [i.strip() for i in v.split(",")]
     elif isinstance(v, list | str):
         return v

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,9 +18,7 @@ from typing_extensions import Self
 
 def parse_cors(v: Any) -> list[str] | str:
     if isinstance(v, str) and not v.startswith("["):
-        if not v.strip():
-            return []
-        return [i.strip() for i in v.split(",")]
+        return [i.strip() for i in v.split(",") if i.strip()]
     elif isinstance(v, list | str):
         return v
     raise ValueError(v)


### PR DESCRIPTION
Fix the `parse_cors` function in `config.py` so that it behaves consistently for both empty string and empty list.
Currently, when an empty list is provided as an argument, it returns an empty list (`[]`). However, when an empty string (`""`) is provided, it returns a list with an empty string (`[""]`) and starting the FastAPI application fails.