### PR TITLE
📝 Add additional notes about `.env` and `.copier-answers.yml` not being in `.gitignore` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You can (and should) pass these as environment variables from secrets.
 
 Read the [deployment.md](./deployment.md) docs for more details.
 
-Also note that the `.env` file is not included in `.gitignore` by default. See [development.md](./development.md#the-env-file) for more details.
+**Note**: The `.env` file is not included in `.gitignore` by default. See [development.md](./development.md#the-env-file) for more details.
 
 ### Generate Secret Keys
 
@@ -193,6 +193,8 @@ pipx run copier copy https://github.com/fastapi/full-stack-fastapi-template my-a
 ```
 
 **Note** the `--trust` option is necessary to be able to execute a [post-creation script](https://github.com/fastapi/full-stack-fastapi-template/blob/master/.copier/update_dotenv.py) that updates your `.env` files.
+
+**Note**: After generating the project, the `.copier/.copier-answers.yml` file contains the values you provided for the template variables, including secrets. If your project is public, you should remove this file and store it somewhere safe or add it to your `.gitignore` to avoid exposing sensitive information.
 
 ### Input Variables
 


### PR DESCRIPTION
Based on previous discussions (#724, #1119, #383, #218, #128, #122), it's clear that we don't want to go ahead and add files containing secrets (e.g. `.env`, `.copier-answers.yml`) to the template's `.gitignore` by default.

This PR surfaces that information to the main `README.md`. Hopefully, this will help make that decision more visible to those getting started with the project and reduce additional issues/discussions opened on the topic.