### PR TITLE
🐛 Fix loginAccessToken Prop in useAuth.ts to Resolve 400 Error on dashboard login

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -46,7 +46,8 @@ const useAuth = () => {
       formData: {
         username: data.username,
         password: data.password,
-      })
+      },
+    })
     localStorage.setItem("access_token", response.access_token)
   }
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -43,8 +43,10 @@ const useAuth = () => {
 
   const login = async (data: AccessToken) => {
     const response = await LoginService.loginAccessToken({
-      formData: data,
-    })
+      formData: {
+        username: data.username,
+        password: data.password,
+      })
     localStorage.setItem("access_token", response.access_token)
   }
 


### PR DESCRIPTION
This pull request fixes an HTTP 400 error in production by updating the login function in frontend/src/hooks/useAuth.ts. The LoginService.loginAccessToken call was incorrectly passing { formData: data } instead of { formData: { data.username, data.password } }, causing a type mismatch and sending multipart/form-data instead of application/x-www-form-urlencoded. The change ensures compliance with the LoginLoginAccessTokenData type and corrects the login request format.