### PR TITLE
🚨 Fix correct return type for `SQLALCHEMY_DATABASE_URI` computed field

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,7 +11,6 @@ from pydantic import (
     computed_field,
     model_validator,
 )
-from pydantic_core import MultiHostUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 


### PR DESCRIPTION
Replace MultiHostUrl.build() with PostgresDsn.build() to match the PostgresDsn return type annotation and resolve type checker error

Fix for the error:
> Type "MultiHostUrl" is not assignable to return type "PostgresDsn"
>  "MultiHostUrl" is not assignable to "PostgresDsn"