### PR TITLE
🚸 Add Postgres password min length validation in `copier.yml`

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -55,7 +55,7 @@ postgres_password:
   default: changethis
 validate: |
   {% if postgres_password|length < 8 %}
-  Password must have at least 8 characters
+  Password must have at least 8 characters. Try again
   {% endif %}
 
 sentry_dsn:


### PR DESCRIPTION
Ensure min lenght for postgresql password