### PR TITLE
🔧 Add isort configuration to enforce separate sorting for tests

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -67,3 +67,6 @@ ignore = [
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
+
+[tool.ruff.lint.isort]
+forced-separate = ["tests"]


### PR DESCRIPTION
🔧 Add isort configuration to enforce separate sorting for tests