### PR TITLE
📝 Update code example to limit the length of generated secret value by 40 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Some environment variables in the `.env` file have a default value of `changethi
 You have to change them with a secret key, to generate secret keys you can run the following command:
 
 ```bash
-python -c "import secrets; print(secrets.token_urlsafe(32))"
+python -c "import secrets; print(secrets.token_urlsafe(32)[:40])"
 ```
 
 Copy the content and use that as password / secret key. And run that again to generate another secure key.

--- a/copier.yml
+++ b/copier.yml
@@ -13,7 +13,7 @@ secret_key:
   help: |
     'The secret key for the project, used for security,
     stored in .env, you can generate one with:
-    python -c "import secrets; print(secrets.token_urlsafe(32))"'
+    python -c "import secrets; print(secrets.token_urlsafe(32)[:40])"'
   default: changethis
 
 first_superuser:
@@ -51,7 +51,7 @@ postgres_password:
   help: |
     'The password for the PostgreSQL database, stored in .env,
     you can generate one with:
-    python -c "import secrets; print(secrets.token_urlsafe(32))"'
+    python -c "import secrets; print(secrets.token_urlsafe(32)[:40])"'
   default: changethis
 
 sentry_dsn:

--- a/deployment.md
+++ b/deployment.md
@@ -158,7 +158,7 @@ Some environment variables in the `.env` file have a default value of `changethi
 You have to change them with a secret key, to generate secret keys you can run the following command:
 
 ```bash
-python -c "import secrets; print(secrets.token_urlsafe(32))"
+python -c "import secrets; print(secrets.token_urlsafe(32)[:40])"
 ```
 
 Copy the content and use that as password / secret key. And run that again to generate another secure key.


### PR DESCRIPTION
In docs we instruct users to use `python -c "import secrets; print(secrets.token_urlsafe(32))"` to generate secrets for all parameters that have default `changethis` value ([source](https://github.com/fastapi/full-stack-fastapi-template/blob/master/README.md#generate-secret-keys)).

Since `token_urlsafe` uses Base64 encoding, the length of generated token is actually not always less than 40 characters (it's 32*1.3=41.6 in average, see [docs](https://docs.python.org/3/library/secrets.html#secrets.token_urlsafe)).
This leads to app failure on start due to violating the constraint of first user password (currently limited by 40, there is a PR https://github.com/fastapi/full-stack-fastapi-template/pull/1447 to increase the limit).

I updated the code example to generate secret value in docs and in `copier.yml` (for the sake of consistency).

Alternatively (IMO, even better) we can just merge https://github.com/fastapi/full-stack-fastapi-template/pull/1447
