### PR TITLE
🐛 Fix `EMAILS_FROM_NAME` type to be `str` instead of `EmailStr`

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -75,7 +75,7 @@ class Settings(BaseSettings):
     SMTP_USER: str | None = None
     SMTP_PASSWORD: str | None = None
     EMAILS_FROM_EMAIL: EmailStr | None = None
-    EMAILS_FROM_NAME: EmailStr | None = None
+    EMAILS_FROM_NAME: str | None = None
 
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:


### PR DESCRIPTION
`EMAILS_FROM_NAME` has default `PROJECT_NAME`, which is a string like "Full Stack FastAPI Project" and not a valid email address. Therefore, the type of `EMAILS_FROM_NAME` should be changed from email to str.