### PR TITLE
fix: Ensure consistent passphrase length

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Some environment variables in the `.env` file have a default value of `changethi
 You have to change them with a secret key, to generate secret keys you can run the following command:
 
 ```bash
-python -c "import secrets; print(secrets.token_urlsafe(32))"
+python -c "import secrets; print(secrets.token_urlsafe(32))[:31]"
 ```
 
 Copy the content and use that as password / secret key. And run that again to generate another secure key.

--- a/copier.yml
+++ b/copier.yml
@@ -13,7 +13,7 @@ secret_key:
   help: |
     'The secret key for the project, used for security,
     stored in .env, you can generate one with:
-    python -c "import secrets; print(secrets.token_urlsafe(32))"'
+    python -c "import secrets; print(secrets.token_urlsafe(32)[:31])"'
   default: changethis
 
 first_superuser:
@@ -51,7 +51,7 @@ postgres_password:
   help: |
     'The password for the PostgreSQL database, stored in .env,
     you can generate one with:
-    python -c "import secrets; print(secrets.token_urlsafe(32))"'
+    python -c "import secrets; print(secrets.token_urlsafe(32)[:31])"'
   default: changethis
 
 sentry_dsn:


### PR DESCRIPTION
This PR ensures that the generated passphrases have a consistent length. 

During the docker compose, some service complained that the secret were too long, which is caused by the `python -c "import secrets; print(secrets.token_urlsafe(32))` which is in bytes, not characters.