### PR TITLE
🐛 Ensure frontend waits for backend and redirect unauthenticated users

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -101,6 +101,9 @@ services:
       args:
         - VITE_API_URL=http://localhost:8000
         - NODE_ENV=development
+    depends_on:
+      backend:
+        condition: service_healthy
 
   playwright:
     build:

--- a/frontend/src/routes/_layout/index.tsx
+++ b/frontend/src/routes/_layout/index.tsx
@@ -1,10 +1,17 @@
 import { Box, Container, Text } from "@chakra-ui/react"
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
-import useAuth from "@/hooks/useAuth"
+import useAuth, { isLoggedIn } from "@/hooks/useAuth"
 
 export const Route = createFileRoute("/_layout/")({
   component: Dashboard,
+  beforeLoad: async () => {
+    if (!isLoggedIn()) {
+      throw redirect({
+        to: "/login",
+      })
+    }
+  },
 })
 
 function Dashboard() {


### PR DESCRIPTION
- Add depends_on to frontend service to wait for backend healthcheck
- Add beforeLoad guard to dashboard route to redirect to login when not authenticated
- Prevents nginx 'host not found' errors and infinite loading spinner