### PR TITLE
fix: resolve 6 failing Playwright E2E tests

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -23,7 +23,7 @@ import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
 
 const formSchema = z.object({
-  username: z.email(),
+  username: z.email({ message: "Invalid email address" }),
   password: z
     .string()
     .min(1, { message: "Password is required" })

--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -25,7 +25,7 @@ import useCustomToast from "@/hooks/useCustomToast"
 import { handleError } from "@/utils"
 
 const formSchema = z.object({
-  email: z.email(),
+  email: z.email({ message: "Invalid email address" }),
 })
 
 type FormData = z.infer<typeof formSchema>

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -22,7 +22,7 @@ import useAuth, { isLoggedIn } from "@/hooks/useAuth"
 
 const formSchema = z
   .object({
-    email: z.email(),
+    email: z.email({ message: "Invalid email address" }),
     full_name: z.string().min(1, { message: "Full Name is required" }),
     password: z
       .string()

--- a/frontend/tests/reset-password.spec.ts
+++ b/frontend/tests/reset-password.spec.ts
@@ -43,6 +43,9 @@ test("User can reset password successfully using the link", async ({
   await page.getByTestId("email-input").fill(email)
 
   await page.getByRole("button", { name: "Continue" }).click()
+  await expect(
+    page.getByText("Password recovery email sent successfully"),
+  ).toBeVisible()
 
   const emailData = await findLastEmail({
     request,
@@ -98,6 +101,9 @@ test("Weak new password validation", async ({ page, request }) => {
   await page.goto("/recover-password")
   await page.getByTestId("email-input").fill(email)
   await page.getByRole("button", { name: "Continue" }).click()
+  await expect(
+    page.getByText("Password recovery email sent successfully"),
+  ).toBeVisible()
 
   const emailData = await findLastEmail({
     request,

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -77,19 +77,21 @@ test("Sign up with existing email", async ({ page }) => {
 
   // Sign up with an email
   await page.goto("/signup")
-
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
+
+  // Wait for first signup to complete (navigates to /login on success)
+  await page.waitForURL("/login")
 
   // Sign up again with the same email
   await page.goto("/signup")
-
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await page
-    .getByText("The user with this email already exists in the system")
-    .click()
+  // Properly assert error message is visible
+  await expect(
+    page.getByText("The user with this email already exists in the system"),
+  ).toBeVisible()
 })
 
 test("Sign up with weak password", async ({ page }) => {

--- a/frontend/tests/utils/user.ts
+++ b/frontend/tests/utils/user.ts
@@ -13,7 +13,9 @@ export async function signUpNewUser(
   await page.getByTestId("password-input").fill(password)
   await page.getByTestId("confirm-password-input").fill(password)
   await page.getByRole("button", { name: "Sign Up" }).click()
-  await page.goto("/login")
+
+  // Wait for signup to complete (redirects to /login on success)
+  await page.waitForURL("/login")
 }
 
 export async function logInUser(page: Page, email: string, password: string) {


### PR DESCRIPTION
## Summary

This PR fixes 6 failing Playwright E2E tests by addressing root causes in both the frontend validation schemas and test implementations.

### Issues Fixed

**Email Validation Messages (4 tests)**
- Tests expected "Invalid email address" but Zod's default message was different
- Added custom error message `{ message: "Invalid email address" }` to email validation in:
  - `login.tsx`
  - `signup.tsx`
  - `recover-password.tsx`

**Password Reset Tests (2 tests)**
- Tests were polling mailcatcher before the email was sent
- Added wait for success toast "Password recovery email sent successfully" before polling

**Sign Up with Existing Email (1 test)**
- Test didn't wait for first signup to complete before attempting second signup
- Changed assertion from `.click()` to proper `.toBeVisible()`

**Root Cause Fix**
- Fixed `signUpNewUser` utility to wait for signup completion (`waitForURL("/login")`) instead of immediately navigating away

## Test Plan

- [x] All 41 Playwright tests pass locally
- [x] Changes are minimal and targeted to fix only the failing tests

## Files Changed

- `frontend/src/routes/login.tsx`
- `frontend/src/routes/signup.tsx`
- `frontend/src/routes/recover-password.tsx`
- `frontend/tests/reset-password.spec.ts`
- `frontend/tests/sign-up.spec.ts`
- `frontend/tests/utils/user.ts`
