### PR TITLE
👷 Configure coverage, error on main tests, don't wait for Smokeshow

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -39,3 +39,6 @@ jobs:
           name: coverage-html
           path: backend/htmlcov
           include-hidden-files: true
+      - name: Coverage report
+        run: uv run coverage report --fail-under=90
+        working-directory: backend


### PR DESCRIPTION
👷 Configure coverage, error on main tests, don't wait for Smokeshow

Same as https://github.com/fastapi/fastapi/pull/14536

Coverage threshold is 90% (as in [smokeshow config](https://github.com/fastapi/full-stack-fastapi-template/blob/6a91475bf61ae1655b1c9b3cedd0bd15a0e35d8c/.github/workflows/smokeshow.yml#L31) and as in current report)