### PR TITLE
Frontend hot reload via docker compose watch

### DIFF
--- a/compose.override.yml
+++ b/compose.override.yml
@@ -99,11 +99,27 @@ services:
       - "5173:80"
     build:
       context: .
-      dockerfile: frontend/Dockerfile
+      dockerfile: frontend/Dockerfile.dev
       args:
         - VITE_API_URL=http://localhost:8000
         - NODE_ENV=development
-
+    command:
+      - bun
+      - run
+      - dev
+      - "--host"
+      - "--port"
+      - "80"
+    develop:
+      watch:
+        - path: ./frontend
+          action: sync
+          target: /app/frontend
+          ignore:
+            - ./frontend/node_modules
+            - node_modules
+        - path: ./frontend/package.json
+          action: rebuild
   playwright:
     build:
       context: .

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,15 @@
+# Stage 0, "build-stage", based on Bun, to build and compile the frontend
+FROM oven/bun:1 AS build-stage
+
+WORKDIR /app
+
+COPY package.json bun.lock /app/
+
+COPY frontend/package.json /app/frontend/
+
+WORKDIR /app/frontend
+
+RUN bun install
+
+COPY ./frontend /app/frontend
+ARG VITE_API_URL


### PR DESCRIPTION
Runs the vite dev server in the frontend container in local instead of building static files. `docker compose watch` should now hot reload on backend *and* frontend changes.