### PR TITLE
fix: remove unused os import in alembic env.py

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -1,4 +1,3 @@
-import os
 from logging.config import fileConfig
 
 from alembic import context


### PR DESCRIPTION
Hi!
I noticed that the os module is imported at the top of backend/app/alembic/env.py but is never actually.

Removed the unused import to keep the file clean.