### PR TITLE
✨ Add clear error message for missing route tags in `app/main.py`

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,11 @@ from app.core.config import settings
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
+    if not route.tags:
+        raise ValueError(
+            f"Route '{route.name}' is missing a tag. Each route "
+            "must have at least one tag for client generation."
+        )
     return f"{route.tags[0]}-{route.name}"
 
 


### PR DESCRIPTION
Added a guard statement with a clear error message when a route is missing tags. 

Currently, when you miss setting up a tag you get an error like:
```
return f"{route.tags[0]}-{route.name}"
          ~~~~~~~~~~^^^
IndexError: list index out of range
```

With the proposed changes, the developer sees:
```
ValueError: Route 'my_new_route' is missing a tag. Each route must have at least one tag for client generation.
```

I believe this improves developer experience and saves debugging time for anyone using the template.
Thank you!