### PR TITLE
🔧 Fix invalid email error message

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -23,7 +23,7 @@ import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
 
 const formSchema = z.object({
-  username: z.email(),
+  username: z.email({ message: "Invalid email address" }),
   password: z
     .string()
     .min(1, { message: "Password is required" })

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -22,7 +22,7 @@ import useAuth, { isLoggedIn } from "@/hooks/useAuth"
 
 const formSchema = z
   .object({
-    email: z.email(),
+    email: z.email({ message: "Invalid email address" }),
     full_name: z.string().min(1, { message: "Full Name is required" }),
     password: z
       .string()


### PR DESCRIPTION
Hey!
I propose this change because it sets the correct message expected by playwright tests.
Prior to this change, the playwright tests checking user logging in or signing up with an incorrect email failed.