### PR TITLE
upgrade Node.js 20 actions

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,7 +12,7 @@ jobs:
     name: Add to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      - uses: actions/add-to-project@1f2db0f17f4dca7786abfab9ca41e2bdcca1e27a # v2.0.0
         with:
           project-url: https://github.com/orgs/fastapi/projects/2
           github-token: ${{ secrets.PROJECTS_TOKEN }}


### PR DESCRIPTION
Warning: https://github.com/fastapi/full-stack-fastapi-template/actions/runs/25828315955

[Add to project](https://github.com/fastapi/full-stack-fastapi-template/actions/runs/25828315955/job/75886998225#step:3:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Pre-commit action is also having a warning, but there is no merged fix yet: https://github.com/fastapi/full-stack-fastapi-template/actions/runs/25828316739
