### PR TITLE
✏️ Fix typo in the comment for DOMAIN in the .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Domain
 # This would be set to the production domain with an env var on deployment
-# used by Traefik to transmit traffic and aqcuire TLS certificates
+# used by Traefik to transmit traffic and acquire TLS certificates
 DOMAIN=localhost
 # To test the local Traefik config
 # DOMAIN=localhost.tiangolo.com


### PR DESCRIPTION
Fix typo in the comment for `DOMAIN` in the [.env](https://github.com/fastapi/full-stack-fastapi-template/blob/master/.env) file.