### PR TITLE
👷 Add pre-commit hook to catch typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
             )$
       - id: trailing-whitespace
         exclude: ^frontend/src/client/.*
+  - repo: https://github.com/crate-ci/typos
+    rev: bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0
+    hooks:
+      - id: typos
+        args: [--force-exclude]
+
   - repo: local
     hooks:
       - id: local-biome-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
     hooks:
       - id: typos
         args: [--force-exclude]
-
   - repo: local
     hooks:
       - id: local-biome-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,18 @@ dev = [
 github-actions = [
     "smokeshow >=0.5.0",
 ]
+
+[tool.typos.files]
+extend-exclude = [
+    "img/",
+    "release-notes.md",
+    "uv.lock",
+    "bun.lock",
+    "backend/coverage/",
+    "backend/htmlcov/",
+    "frontend/dist/",
+    "frontend/public/assets/images/",
+]
+
+[tool.typos.default.extend-identifiers]
+alls = "alls"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,20 @@ github-actions = [
 [tool.typos.files]
 extend-exclude = [
     "img/",
-    "release-notes.md",
     "uv.lock",
     "bun.lock",
     "backend/coverage/",
     "backend/htmlcov/",
     "frontend/dist/",
     "frontend/public/assets/images/",
+]
+
+[tool.typos.default]
+extend-ignore-re = [
+    # GitHub usernames in @mentions
+    "@[a-zA-Z0-9](?:-?[a-zA-Z0-9])*",
+    # Name of the package in the PR title
+    "Bump certifi ",
 ]
 
 [tool.typos.default.extend-identifiers]


### PR DESCRIPTION
Set up pre-commit hook to catch typos in sources.
Same as in https://github.com/fastapi/fastapi/pull/15482

No typos currently found by `prek run typos --all-files` - the only one was `aqcuire` in `.env`, but it was fixed by https://github.com/fastapi/full-stack-fastapi-template/pull/2305/changes
