### PR TITLE
📝 Simplify error message for non-existent user in password recovery

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -111,7 +111,7 @@ def recover_password_html_content(email: str, session: SessionDep) -> Any:
     if not user:
         raise HTTPException(
             status_code=404,
-            detail="The user with this username does not exist in the system.",
+            detail="User does not exist.",
         )
     password_reset_token = generate_password_reset_token(email=email)
     email_data = generate_reset_password_email(


### PR DESCRIPTION
## Pull Request
Simplify error message 

## Description
This makes the reponse shoter and remove unnessary message like ".... username don't exit in the system" for better security with telling fake users that the name don't exist in the system instead we can just tell them the user does not exist.

Updated the response message from:
"The user with this username does not exist in the system."
to:
"User does not exist"



## AI Disclaimer

No AI used

## Checklist

- [x] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
