### PR TITLE
chore(docker): upgrade base image from python:3.10 to python:3.12-sli…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.12-slim-trixie
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
# Upgrade Docker base image to Python 3.12 slim

## Summary

* Upgrade Docker base image from `python:3.10` to `python:3.12-slim-trixie`
* Reduce container image size by using the slim variant
* Update runtime environment to Python 3.12

## Testing

* Docker image builds successfully
* No application code changes
