### PR TITLE
📝 Improve README screenshot alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@
 
 ### Dashboard Login
 
-[![API docs](img/login.png)](https://github.com/fastapi/full-stack-fastapi-template)
+[![Dashboard login screenshot](img/login.png)](https://github.com/fastapi/full-stack-fastapi-template)
 
 ### Dashboard - Admin
 
-[![API docs](img/dashboard.png)](https://github.com/fastapi/full-stack-fastapi-template)
+[![Admin dashboard screenshot](img/dashboard.png)](https://github.com/fastapi/full-stack-fastapi-template)
 
 ### Dashboard - Items
 
-[![API docs](img/dashboard-items.png)](https://github.com/fastapi/full-stack-fastapi-template)
+[![Items dashboard screenshot](img/dashboard-items.png)](https://github.com/fastapi/full-stack-fastapi-template)
 
 ### Dashboard - Dark Mode
 
-[![API docs](img/dashboard-dark.png)](https://github.com/fastapi/full-stack-fastapi-template)
+[![Dark mode dashboard screenshot](img/dashboard-dark.png)](https://github.com/fastapi/full-stack-fastapi-template)
 
 ### Interactive API Documentation
 


### PR DESCRIPTION
## Description

Updates the README screenshot alt text so each dashboard image describes the screenshot it links to instead of reusing `API docs` for every image.

The API documentation screenshot keeps the `API docs` label.

## Validation

- `rg -n "\[!\[API docs\]|Dashboard login screenshot|Admin dashboard screenshot|Items dashboard screenshot|Dark mode dashboard screenshot" README.md`
- `git diff --check`