### PR TITLE
feat: add example environment variable templates for backend and frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# Domain
+# This would be set to the production domain with an env var on deployment
+# used by Traefik to transmit traffic and acquire TLS certificates
+DOMAIN=localhost
+# To test the local Traefik config
+# DOMAIN=localhost.tiangolo.com
+
+# Used by the backend to generate links in emails to the frontend
+FRONTEND_HOST=http://localhost:5173
+# In staging and production, set this env var to the frontend host, e.g.
+# FRONTEND_HOST=https://dashboard.example.com
+
+# Environment: local, staging, production
+ENVIRONMENT=local
+
+PROJECT_NAME="Full Stack FastAPI Project"
+STACK_NAME=full-stack-fastapi-project
+
+# Backend
+BACKEND_CORS_ORIGINS="http://localhost,http://localhost:5173,https://localhost,https://localhost:5173,http://localhost.tiangolo.com"
+SECRET_KEY=
+FIRST_SUPERUSER=
+FIRST_SUPERUSER_PASSWORD=
+
+# Emails
+SMTP_HOST=
+SMTP_USER=
+SMTP_PASSWORD=
+EMAILS_FROM_EMAIL=
+SMTP_TLS=True
+SMTP_SSL=False
+SMTP_PORT=587
+
+# Postgres
+POSTGRES_SERVER=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=app
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+
+SENTRY_DSN=
+
+# Configure these with your own Docker registry images
+DOCKER_IMAGE_BACKEND=backend
+DOCKER_IMAGE_FRONTEND=frontend

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8000
+MAILCATCHER_HOST=http://localhost:1080


### PR DESCRIPTION
## Pull Request

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Typos, grammar issues, broken links and other small docs improvements should be reported in the pinned Discussion thread "✏️ Report small docs improvements, including typos or broken links".
Please do not open a PR for these yourself.
-->

Discussion: <!-- Link to the GitHub Discussion -->

## Description

I added `.env.example` to prevent `.env` push of sensitive data.

Updated both `.env.example` files to preserve all comments and default static configuration values (such as `localhost`, ports, SMTP TLS/SSL, VITE_API_URL, etc.), while clearing out only the sensitive/secret placeholder values (such as `changethis`, `admin@example.com`, and `info@example.com`).

## AI Disclaimer

<!-- If using AI, write here the prompt and model used -->

<details>
<summary>AI transcript</summary>

<!-- Paste here the entire AI transcript -->

</details>

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
