### PR TITLE
Feature/pagination refactor

### DIFF
--- a/backend/app/api/routes/items.py
+++ b/backend/app/api/routes/items.py
@@ -5,7 +5,14 @@ from fastapi import APIRouter, HTTPException
 from sqlmodel import col, func, select
 
 from app.api.deps import CurrentUser, SessionDep
-from app.models import Item, ItemCreate, ItemPublic, PaginatedResponse, ItemUpdate, Message
+from app.models import (
+    Item,
+    ItemCreate,
+    ItemPublic,
+    ItemUpdate,
+    Message,
+    PaginatedResponse,
+)
 
 router = APIRouter(prefix="/items", tags=["items"])
 

--- a/backend/app/api/routes/items.py
+++ b/backend/app/api/routes/items.py
@@ -5,12 +5,12 @@ from fastapi import APIRouter, HTTPException
 from sqlmodel import col, func, select
 
 from app.api.deps import CurrentUser, SessionDep
-from app.models import Item, ItemCreate, ItemPublic, ItemsPublic, ItemUpdate, Message
+from app.models import Item, ItemCreate, ItemPublic, PaginatedResponse, ItemUpdate, Message
 
 router = APIRouter(prefix="/items", tags=["items"])
 
 
-@router.get("/", response_model=ItemsPublic)
+@router.get("/", response_model=PaginatedResponse[ItemPublic])
 def read_items(
     session: SessionDep, current_user: CurrentUser, skip: int = 0, limit: int = 100
 ) -> Any:
@@ -42,7 +42,7 @@ def read_items(
         items = session.exec(statement).all()
 
     items_public = [ItemPublic.model_validate(item) for item in items]
-    return ItemsPublic(data=items_public, count=count)
+    return PaginatedResponse(data=items_public, count=count)
 
 
 @router.get("/{id}", response_model=ItemPublic)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -15,12 +15,12 @@ from app.core.security import get_password_hash, verify_password
 from app.models import (
     Item,
     Message,
+    PaginatedResponse,
     UpdatePassword,
     User,
     UserCreate,
     UserPublic,
     UserRegister,
-    PaginatedResponse,
     UserUpdate,
     UserUpdateMe,
 )

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -20,7 +20,7 @@ from app.models import (
     UserCreate,
     UserPublic,
     UserRegister,
-    UsersPublic,
+    PaginatedResponse,
     UserUpdate,
     UserUpdateMe,
 )
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/users", tags=["users"])
 @router.get(
     "/",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=UsersPublic,
+    response_model=PaginatedResponse[UserPublic],
 )
 def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
     """
@@ -48,7 +48,7 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
     users = session.exec(statement).all()
 
     users_public = [UserPublic.model_validate(user) for user in users]
-    return UsersPublic(data=users_public, count=count)
+    return PaginatedResponse(data=users_public, count=count)
 
 
 @router.post(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import UTC, datetime
+from typing import Generic, TypeVar
 
 from pydantic import EmailStr
 from sqlalchemy import DateTime
@@ -8,6 +9,13 @@ from sqlmodel import Field, Relationship, SQLModel
 
 def get_datetime_utc() -> datetime:
     return datetime.now(UTC)
+
+
+T = TypeVar("T")
+
+class PaginatedResponse(SQLModel, Generic[T]):
+    data: list[T]
+    count: int
 
 
 # Shared properties
@@ -65,11 +73,6 @@ class UserPublic(UserBase):
     created_at: datetime | None = None
 
 
-class UsersPublic(SQLModel):
-    data: list[UserPublic]
-    count: int
-
-
 # Shared properties
 class ItemBase(SQLModel):
     title: str = Field(min_length=1, max_length=255)
@@ -105,11 +108,6 @@ class ItemPublic(ItemBase):
     id: uuid.UUID
     owner_id: uuid.UUID
     created_at: datetime | None = None
-
-
-class ItemsPublic(SQLModel):
-    data: list[ItemPublic]
-    count: int
 
 
 # Generic message

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -13,6 +13,7 @@ def get_datetime_utc() -> datetime:
 
 T = TypeVar("T")
 
+
 class PaginatedResponse(SQLModel, Generic[T]):
     data: list[T]
     count: int

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -177,25 +177,6 @@ export const ItemUpdateSchema = {
     title: 'ItemUpdate'
 } as const;
 
-export const ItemsPublicSchema = {
-    properties: {
-        data: {
-            items: {
-                '$ref': '#/components/schemas/ItemPublic'
-            },
-            type: 'array',
-            title: 'Data'
-        },
-        count: {
-            type: 'integer',
-            title: 'Count'
-        }
-    },
-    type: 'object',
-    required: ['data', 'count'],
-    title: 'ItemsPublic'
-} as const;
-
 export const MessageSchema = {
     properties: {
         message: {
@@ -224,6 +205,40 @@ export const NewPasswordSchema = {
     type: 'object',
     required: ['token', 'new_password'],
     title: 'NewPassword'
+} as const;
+
+export const PaginatedResponse_ItemPublic_Schema = {
+    properties: {
+        data: {
+            items: {},
+            type: 'array',
+            title: 'Data'
+        },
+        count: {
+            type: 'integer',
+            title: 'Count'
+        }
+    },
+    type: 'object',
+    required: ['data', 'count'],
+    title: 'PaginatedResponse[ItemPublic]'
+} as const;
+
+export const PaginatedResponse_UserPublic_Schema = {
+    properties: {
+        data: {
+            items: {},
+            type: 'array',
+            title: 'Data'
+        },
+        count: {
+            type: 'integer',
+            title: 'Count'
+        }
+    },
+    type: 'object',
+    required: ['data', 'count'],
+    title: 'PaginatedResponse[UserPublic]'
 } as const;
 
 export const PrivateUserCreateSchema = {
@@ -512,25 +527,6 @@ export const UserUpdateMeSchema = {
     },
     type: 'object',
     title: 'UserUpdateMe'
-} as const;
-
-export const UsersPublicSchema = {
-    properties: {
-        data: {
-            items: {
-                '$ref': '#/components/schemas/UserPublic'
-            },
-            type: 'array',
-            title: 'Data'
-        },
-        count: {
-            type: 'integer',
-            title: 'Count'
-        }
-    },
-    type: 'object',
-    required: ['data', 'count'],
-    title: 'UsersPublic'
 } as const;
 
 export const ValidationErrorSchema = {

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -12,7 +12,7 @@ export class ItemsService {
      * @param data The data for the request.
      * @param data.skip
      * @param data.limit
-     * @returns ItemsPublic Successful Response
+     * @returns PaginatedResponse_ItemPublic_ Successful Response
      * @throws ApiError
      */
     public static readItems(data: ItemsReadItemsData = {}): CancelablePromise<ItemsReadItemsResponse> {
@@ -242,7 +242,7 @@ export class UsersService {
      * @param data The data for the request.
      * @param data.skip
      * @param data.limit
-     * @returns UsersPublic Successful Response
+     * @returns PaginatedResponse_UserPublic_ Successful Response
      * @throws ApiError
      */
     public static readUsers(data: UsersReadUsersData = {}): CancelablePromise<UsersReadUsersResponse> {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -26,11 +26,6 @@ export type ItemPublic = {
     created_at?: (string | null);
 };
 
-export type ItemsPublic = {
-    data: Array<ItemPublic>;
-    count: number;
-};
-
 export type ItemUpdate = {
     title?: (string | null);
     description?: (string | null);
@@ -43,6 +38,16 @@ export type Message = {
 export type NewPassword = {
     token: string;
     new_password: string;
+};
+
+export type PaginatedResponse_ItemPublic_ = {
+    data: Array<unknown>;
+    count: number;
+};
+
+export type PaginatedResponse_UserPublic_ = {
+    data: Array<unknown>;
+    count: number;
 };
 
 export type PrivateUserCreate = {
@@ -85,11 +90,6 @@ export type UserRegister = {
     full_name?: (string | null);
 };
 
-export type UsersPublic = {
-    data: Array<UserPublic>;
-    count: number;
-};
-
 export type UserUpdate = {
     email?: (string | null);
     is_active?: (boolean | null);
@@ -118,7 +118,7 @@ export type ItemsReadItemsData = {
     skip?: number;
 };
 
-export type ItemsReadItemsResponse = (ItemsPublic);
+export type ItemsReadItemsResponse = (PaginatedResponse_ItemPublic_);
 
 export type ItemsCreateItemData = {
     requestBody: ItemCreate;
@@ -182,7 +182,7 @@ export type UsersReadUsersData = {
     skip?: number;
 };
 
-export type UsersReadUsersResponse = (UsersPublic);
+export type UsersReadUsersResponse = (PaginatedResponse_UserPublic_);
 
 export type UsersCreateUserData = {
     requestBody: UserCreate;


### PR DESCRIPTION
## Pull Request

Discussion: N/A

## Description

This PR refactors the paginated response models to use a single Generic type, eliminating code duplication between users and items. 
Previously, `models.py` defined separate models for each entity list:
- `UsersPublic(SQLModel)`
- `ItemsPublic(SQLModel)`
This implementation replaces them with a single generic `PaginatedResponse[T]` model:
```python
T = TypeVar("T")
class PaginatedResponse(SQLModel, Generic[T]):
    data: list[T]
    count: int

This ensures consistency across all current and future endpoints that require pagination (e.g., returning PaginatedResponse[UserPublic] or PaginatedResponse[ItemPublic]) and reduces boilerplate code in the models file.

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
