### PR TITLE
chore(docker): Migrate to statement that supports Dependabot `uv` upgrades

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,6 @@
+# ==============================================================================
+# Frontend: build
+# ==============================================================================
 FROM oven/bun:1 AS frontend-build
 
 WORKDIR /app
@@ -15,14 +18,17 @@ ARG VITE_API_URL=
 
 RUN bun run build
 
+# ==============================================================================
+# Dependency: pull in the standalone uv binary
+# ==============================================================================
+FROM ghcr.io/astral-sh/uv:0.12.2 AS uv-binary
 
-FROM python:3.14
+# ==============================================================================
+# Runtime: backend build + app run
+# ==============================================================================
+FROM python:3.14 AS runtime
 
 ENV PYTHONUNBUFFERED=1
-
-# Install uv
-# Ref: https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /uvx /bin/
 
 # Compile bytecode
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
@@ -37,6 +43,9 @@ WORKDIR /app/
 # Place executables in the environment at the front of the path
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#using-the-environment
 ENV PATH="/app/.venv/bin:$PATH"
+
+# provision package manager
+COPY --from=uv-binary /uv /usr/local/bin/uv
 
 # Install dependencies
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#intermediate-layers


### PR DESCRIPTION
## Description
I noticed upgrades to the `uv` image tags in the `Dockerfile` are manual. See:
- #2102 
- #1454

### Problem
🔴 This results in a version drift for the `uv` binaries used in **GitHub Actions** (`v0.11.18`) and **Docker** (`v0.9.26`). There's an existing Dependabot config for the `docker` [ecosystem](https://github.com/fastapi/full-stack-fastapi-template/blob/master/.github/dependabot.yml#L51), but Dependabot currently doesn't support upgrading version tags embedded in `COPY --from=...` statements (see [issue](https://github.com/dependabot/dependabot-core/issues/5103)).

### Solution
🟢 This PR includes a minor patch to provision the `uv` binary with a `FROM` directive. This will enable Dependabot to parse and suggest PR upgrades to `uv` image version tags. This additionally avoids manual upgrades and prevents version drift.

## Decisions
> This section outlines notable considerations for developers/maintainers.
- Comment blocks were added to distinguish between multi-stage builds for better readability.
- The latest `uv` patch [release](url) version was used: `v0.12.2`
- No change in behavior or output is expected from this change, just an extra line in the `Dockerfile`

> [!NOTE]
> A solid fix moving forward would be to leverage the UV setting, [`required-version`](https://docs.astral.sh/uv/reference/settings/#required-version), to constrain `uv` to a **single version repo-wide** (locally, in-container, gha, etc.). `uv` respects and reads this on each invoke and fails fast if the detected binary (or PYPI) does not match that exact version. This change requires a team member to add the setting to `pyproject.toml` according to this repo's [CONTRIBUTING.md](https://github.com/fastapi/full-stack-fastapi-template/blob/master/CONTRIBUTING.md#discussions-first)

> [!CAUTION]
> A known caveat is that Dependabot currently does not support upgrading `required-version`. A temporary hack would be to have Dependabot infer a `uv` upgrade via a PR, and a maintainer can update the `required-version` setting to the corresponding version.

## Additional
> I initially had another change in mind but intentionally chose to first roll out this before proceeding with the others.
- Omit package manager from final release image (recommended Docker best practice)
- Decouple the backend build from the final stage into its own multi-stage section (`backend-build`)
- Create composite action for the step **`Setup uv`**: This step is currently duplicated across 5 workflow files, some with different names (`Install uv`, `Setup uv`), each defining a `uv` version (`v0.11.18`). Have one composite action and reference it everywhere:
```yml
      - name: Setup uv
        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
        with:
          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
          version-file: "pyproject.toml"  # replaces explicit version, reads `required-version` setting.
          cache-dependency-glob: |
            pyproject.toml
            uv.lock
```

I can follow up with PRs for the above or a Discussion to further discuss the changes if the maintainers deem fit!

## AI Disclaimer
AI wasn't used given the trivial change. It was, however, used for an _extra_ review to ensure things look normal.

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
