### PR TITLE
Add Deply architecture configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ General development docs: [development.md](./development.md).
 
 This includes the local FastAPI and Vite workflow, Docker Compose services, `.env` configuration, and more.
 
+## Architecture Analysis
+
+[Deply](https://github.com/Vashkatsi/deply) provides an optional baseline for this template's pragmatic Active Record-style architecture.
+It does not enforce Clean Architecture boundaries; the [verified recipe](https://vashkatsi.github.io/deply/doc/full-stack-fastapi-template.html) documents the scope and trade-offs.
+
+Run from the project root with the template's Python version:
+
+```bash
+uvx --from deply==1.0.0 --python 3.14 deply validate --config=deply.yaml
+uvx --from deply==1.0.0 --python 3.14 deply analyze --parallel --config=deply.yaml
+```
+
 ## Release Notes
 
 Check the file [release-notes.md](./release-notes.md).

--- a/deply.yaml
+++ b/deply.yaml
@@ -1,0 +1,81 @@
+deply:
+  paths:
+    - backend/app
+
+  exclude_files:
+    - '^alembic/.*'
+
+  layers:
+    - name: interface
+      collectors:
+        - type: bool
+          any_of:
+            - type: directory
+              directories:
+                - api
+              element_type: function
+            - type: directory
+              directories:
+                - api
+              element_type: class
+            - type: file_regex
+              regex: '^api/main\.py$'
+              element_type: variable
+            - type: file_regex
+              regex: '^main\.py$'
+              element_type: function
+
+    - name: data
+      collectors:
+        - type: file_regex
+          regex: '^(crud|models)\.py$'
+          element_type: function
+        - type: file_regex
+          regex: '^(crud|models)\.py$'
+          element_type: class
+
+    - name: infrastructure
+      collectors:
+        - type: bool
+          any_of:
+            - type: directory
+              directories:
+                - core
+              element_type: function
+            - type: directory
+              directories:
+                - core
+              element_type: class
+            - type: file_regex
+              regex: '^utils\.py$'
+              element_type: function
+            - type: file_regex
+              regex: '^utils\.py$'
+              element_type: class
+
+    - name: bootstrap
+      collectors:
+        - type: file_regex
+          regex: '^(backend_pre_start|initial_data|tests_pre_start)\.py$'
+          element_type: function
+
+  ruleset:
+    interface:
+      disallow_layer_dependencies:
+        - bootstrap
+
+    data:
+      disallow_layer_dependencies:
+        - interface
+        - bootstrap
+      disallow_external_imports:
+        - fastapi
+        - starlette
+
+    infrastructure:
+      disallow_layer_dependencies:
+        - interface
+        - bootstrap
+      disallow_external_imports:
+        - fastapi
+        - starlette


### PR DESCRIPTION
## Summary

Adds an opt-in [Deply](https://github.com/Vashkatsi/deply) baseline for the template's current pragmatic Active Record-style architecture and documents how to run it.

This does not claim Clean Architecture boundaries and changes no runtime code, CI, dependencies, or lockfiles. The commands select Python 3.14 explicitly because the template uses Python 3.14 syntax.

Related discussion: https://github.com/fastapi/full-stack-fastapi-template/discussions/2443

## Verification

- Configuration validation passed.
- Analysis found 509 dependencies and 0 violations.
- Layers are pairwise disjoint: interface 29, data 25, infrastructure 18, bootstrap 6.
- `deply.yaml` matches the [verified recipe](https://vashkatsi.github.io/deply/doc/full-stack-fastapi-template.html) byte-for-byte.
- YAML, EOF, and whitespace hooks passed.

## Known check

`typos` treats `Deply` and `deply` as misspellings, including the filename. The clean fix is to allow both identifiers in the existing typos configuration. I left `pyproject.toml` unchanged because contributor policy reserves that file for maintainers.
