### PR TITLE
Updated README.md to include "What is this"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Test Docker Compose](../../actions/workflows/test-docker-compose.yml/badge.svg)](../../actions/workflows/test-docker-compose.yml)
 [![Test Backend](../../actions/workflows/test-backend.yml/badge.svg)](../../actions/workflows/test-backend.yml)
 
+## What Is This?
+- ❓ This repository is a development-ready boilerplate template designed to skip the tedious setup of building a modern web application from scratch. Instead of spending precious time configuring user authentication , setting up databases, connecting a frontend framework, and configuring Docker, this template provides a fully functional general use full-stack ecosystem out of the box.
+
 ## Technology Stack and Features
 
 - ⚡ [**FastAPI**](https://fastapi.tiangolo.com) for the Python backend API.


### PR DESCRIPTION
### Context

The current README.md file jumped straight into the technological stacks and how to use it but never why to use it.

### Changes

Added a brief `## What Is This?` on top of the README.md file right below the main repository title.

### Benefits

This has geniunely confused me for a good while so thought I might add this for any future beginner contributors.
