### PR TITLE
fix(backend): mount frontend route only when FRONTEND_DIR exists

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,4 +33,5 @@ app.add_middleware(
 )
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
-app.frontend("/", directory=FRONTEND_DIR)
+if FRONTEND_DIR.exists():
+    app.frontend("/", directory=FRONTEND_DIR)


### PR DESCRIPTION
### Summary
- Check if `FRONTEND_DIR` exists before calling `app.frontend("/", directory=FRONTEND_DIR)` in `backend/app/main.py`.
- Prevents `RuntimeError` during local backend development or test collection when the frontend build directory is not yet generated or mounted.