### PR TITLE
⬆️ Bump setup-uv action to 10.0.1

### DIFF
--- a/.github/workflows/bump-pre-commit-hooks.yml
+++ b/.github/workflows/bump-pre-commit-hooks.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
-          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
           version: "latest-known"
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/bump-pre-commit-hooks.yml
+++ b/.github/workflows/bump-pre-commit-hooks.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
-          version: "0.11.18"
+          version: "latest-known"
           cache-dependency-glob: |
             pyproject.toml
             uv.lock

--- a/.github/workflows/bump-pre-commit-hooks.yml
+++ b/.github/workflows/bump-pre-commit-hooks.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version-file: ".python-version"
       - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version-file: ".python-version"
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
-          version: "0.11.18"
+          version: "latest-known"
       - name: Extract release details
         id: release-details
         run: |

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
-          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
           version: "latest-known"
       - name: Extract release details
         id: release-details

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           # Override frontend/.env so the deployed frontend uses the same origin as the API
           VITE_API_URL: ""
       - name: Set up uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.18"
       - name: Prepare database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.11.18"
+          version: "latest-known"
       - name: Prepare database
         run: uv run bash scripts/prestart.sh
         working-directory: backend

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -68,8 +68,6 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
-        # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
         version: "latest-known"
     - run: uv sync
       working-directory: backend

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         limit-access-to-actor: true
     - name: Install uv
-      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
         # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -70,7 +70,7 @@ jobs:
       with:
         # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
         # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
-        version: "0.11.18"
+        version: "latest-known"
     - run: uv sync
       working-directory: backend
     - run: bun ci

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
-          version: "0.11.18"
+          version: "latest-known"
           cache-dependency-glob: |
             requirements**.txt
             pyproject.toml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
-          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
           version: "latest-known"
           cache-dependency-glob: |
             requirements**.txt

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           python-version-file: .python-version
       - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version-file: ".python-version"
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,8 +40,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
-          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
           version: "latest-known"
       - name: Prepare release
         env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
-          version: "0.11.18"
+          version: "latest-known"
       - name: Prepare release
         env:
           BUMP: ${{ inputs.bump }}

--- a/.github/workflows/smokeshow.yml
+++ b/.github/workflows/smokeshow.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version-file: .python-version
       - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837

--- a/.github/workflows/smokeshow.yml
+++ b/.github/workflows/smokeshow.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
-          version: "0.11.18"
+          version: "latest-known"
           cache-dependency-glob: |
             pyproject.toml
             uv.lock

--- a/.github/workflows/smokeshow.yml
+++ b/.github/workflows/smokeshow.yml
@@ -26,8 +26,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
-          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
           version: "latest-known"
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version-file: .python-version
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
           # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
-          version: "0.11.18"
+          version: "latest-known"
       - run: docker compose down -v --remove-orphans
       - run: docker compose up -d db mailpit
       - name: Migrate DB

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          # Before upgrading uv version, make sure astral-sh/setup-uv knows its checksum.
-          # See: https://github.com/astral-sh/setup-uv/issues/851#issuecomment-4282017837
           version: "latest-known"
       - run: docker compose down -v --remove-orphans
       - run: docker compose up -d db mailpit


### PR DESCRIPTION
## Description

Version 10.0.0 introduced security-related breaking changes: caching is disabled by default for workflows triggered by `workflow_run`, `pull_request_target`, and `release` events: https://github.com/astral-sh/setup-uv/releases/tag/v10.0.0

This will disable caching for the Smokeshow workflow. Let's keep that behavior for now.

## AI Disclaimer

Used Codex to apply and review the changes. Then reviewed manually
