### PR TITLE
⬆️ Bump Typer min version to `0.26.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [dependency-groups]
 dev = [
     "prek>=0.4.11,<1.0.0",
-    "typer>=0.20.0,<1.0.0",
+    "typer>=0.26.1,<1.0.0",
     "zizmor>=1.28.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ members = [
 [manifest.dependency-groups]
 dev = [
     { name = "prek", specifier = ">=0.4.11,<1.0.0" },
-    { name = "typer", specifier = ">=0.20.0,<1.0.0" },
+    { name = "typer", specifier = ">=0.26.1,<1.0.0" },
     { name = "zizmor", specifier = ">=1.28.0" },
 ]
 github-actions = [{ name = "smokeshow", specifier = ">=0.5.0" }]


### PR DESCRIPTION
Typer version less than 0.26.0 has deprecation warnings with latest version of Click. It doesn't break anything now, but will stop working after Click 9.0 release.

🤖 This pull request was created with the help of AI (Codex).

Checked manually