### PR TITLE
🐛 Fix return 401 instead of 404 when a token's user doesn't exist

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -40,7 +40,10 @@ def get_current_user(session: SessionDep, token: TokenDep) -> User:
         )
     user = session.get(User, token_data.sub)
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        )
     if not user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")
     return user

--- a/backend/tests/api/routes/test_login.py
+++ b/backend/tests/api/routes/test_login.py
@@ -46,6 +46,25 @@ def test_use_access_token(
     assert "email" in result
 
 
+def test_use_access_token_of_deleted_user(client: TestClient, db: Session) -> None:
+    email = random_email()
+    password = random_lower_string()
+    user_create = UserCreate(email=email, password=password, is_active=True)
+    user = create_user(session=db, user_create=user_create)
+    headers = user_authentication_headers(client=client, email=email, password=password)
+
+    db.delete(user)
+    db.commit()
+
+    r = client.post(
+        f"{settings.API_V1_STR}/login/test-token",
+        headers=headers,
+    )
+
+    assert r.status_code == 401
+    assert r.json() == {"detail": "Could not validate credentials"}
+
+
 def test_recovery_password(
     client: TestClient, normal_user_token_headers: dict[str, str]
 ) -> None:


### PR DESCRIPTION
get_current_user returned 404 when the user id it encoded no longer existed. 404 is the wrong code since nothing about the requested resource is missing, the presented credential is just invalid. An issue with the 404 code was that the frontend's global error handler only clears and redirects to login on 401/403.