### PR TITLE
👷 Fix mypy and ty pre-commit hooks not using config from `backend/pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
 
       - id: local-mypy
         name: mypy check
-        entry: uv run mypy backend/app
+        entry: uv run mypy --config-file backend/pyproject.toml backend/app
         require_serial: true
         language: unsupported
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
 
       - id: local-ty
         name: ty check
-        entry: uv run ty check backend/app
+        entry: uv run ty check --project backend backend/app
         require_serial: true
         language: unsupported
         pass_filenames: false


### PR DESCRIPTION
## Description

I recently discovered that mypy running on pre-commit doesn't work the same way as if we run it with `bash scripts/lint.sh`.
The reason is that prek runs it from the root directory and it uses the `pyproject.toml` of the root project, but config is in `backend/pyproject.toml`.

To fix this we need to specify the config file to use in the command.

The same is true for ty. We don't see it currently as the current config is equal to default settings.

To check, modify the mypy config (for example, add `disallow_any_explicit = true` to `[tool.mypy]`) and then run prek from root directory: `prek run local-mypy --all-files`.
This will pass on master (because config is not used) and show lots of `explicit-any` on this branch (this proves that mypy now uses config from `backend/pyproject.toml`).

Same with ty: add `[tool.ty.environment] python-version = "3.9"`, run `prek run local-ty --all-files`, see no errors on `master` and 6 errors on this branch.

## AI Disclaimer

Used Claude Code (Fable 5) to investigate and apply the fix. Checked manually

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
